### PR TITLE
Fixed indentation of namespaceSelector

### DIFF
--- a/spinnaker-service-monitor.yaml
+++ b/spinnaker-service-monitor.yaml
@@ -12,8 +12,8 @@ spec:
   selector:
     matchLabels:
       app: spin
-    namespaceSelector:
-      any: true
+  namespaceSelector:
+    any: true
   endpoints:
   # "port" is string only. "targetPort" is integer or string.
   - targetPort: 8008


### PR DESCRIPTION
Nice talk!  Copy/pasted the example into our existing prom operator and found the indentation on `namespaceSelector` was off.  It should be under `spec`.

